### PR TITLE
fix(build): use CARGO_ENCODED_RUSTFLAGS

### DIFF
--- a/build_rust.sh
+++ b/build_rust.sh
@@ -2,7 +2,8 @@
 
 if [ "`uname`" = "Darwin" ]; then
   CAML_LIB="`ocamlc -where`";
-  RUSTFLAGS="'-L$CAML_LIB' -lcamlrun" cargo build --release --frozen ;
+  SEP="`echo '\x1f'`";
+  CARGO_ENCODED_RUSTFLAGS="-L$CAML_LIB$SEP-lcamlrun" cargo build --release --frozen ;
 else
   cargo build --release --frozen ;
 fi


### PR DESCRIPTION
`RUSTFLAGS` splits the string on whitespace, so quoting `CAML_LIB` won't work.

`CARGO_ENCODED_RUSTFLAGS` splits the string on the ASCII unit separator.

(See https://doc.rust-lang.org/cargo/reference/environment-variables.html)